### PR TITLE
fix: use custom user model

### DIFF
--- a/config/acquaintances.php
+++ b/config/acquaintances.php
@@ -13,6 +13,10 @@ return [
          */
         'interactions' => 'interactions',
         /*
+         * `user_id` foreign key column name within interactions table.
+         */
+        'interactions_user_id_fk_column_name' => 'profile_id',
+        /*
          * `user_id` foreign key column type within interactions table.
          */
         'interactions_user_id_fk_column_type' => 'unsignedBigInteger',

--- a/config/acquaintances.php
+++ b/config/acquaintances.php
@@ -4,7 +4,7 @@ return [
     /*
      * Models Related.
      */
-    'model_namespace' => 'App',
+    'model_namespace' => 'App\Models',
     'user_model_class_name' => 'User',
 
     'tables' => [
@@ -13,11 +13,11 @@ return [
          */
         'interactions' => 'interactions',
         /*
-         * `user_id` foreign key column name within interactions table.
+         * user foreign key column name within interactions table.
          */
-        'interactions_user_id_fk_column_name' => 'profile_id',
+        'interactions_user_id_fk_column_name' => 'user_id',
         /*
-         * `user_id` foreign key column type within interactions table.
+         * user foreign key column type within interactions table.
          */
         'interactions_user_id_fk_column_type' => 'unsignedBigInteger',
         /*

--- a/src/Interaction.php
+++ b/src/Interaction.php
@@ -3,6 +3,7 @@
 namespace Multicaret\Acquaintances;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use stdClass;
 

--- a/src/Interaction.php
+++ b/src/Interaction.php
@@ -211,4 +211,11 @@ class Interaction
 
         return number_format($number / $divisor, $precision).$shorthand;
     }
+
+    static public function getUserModelName() {
+        $namespace = config('acquaintances.model_namespace', 'App');
+        $userClassName = config('acquaintances.user_model_class_name', 'User');
+
+        return $namespace.'\\'.Str::studly($userClassName);
+    }
 }

--- a/src/Models/InteractionRelation.php
+++ b/src/Models/InteractionRelation.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Multicaret\Acquaintances\Interaction;
 
 /**
  * Class InteractionRelation.
@@ -36,12 +37,7 @@ class InteractionRelation extends Model
      */
     public function user()
     {
-        $namespace = config('acquaintances.model_namespace', 'App');
-        $userClassName = config('acquaintances.user_model_class_name', 'User');
-
-        $modelName = $namespace.'\\'.Str::studly($userClassName);
-
-        return $this->belongsTo($modelName);
+        return $this->belongsTo(Interaction::getUserModelName());
     }
 
     /**

--- a/src/Models/InteractionRelation.php
+++ b/src/Models/InteractionRelation.php
@@ -5,7 +5,6 @@ namespace Multicaret\Acquaintances\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Multicaret\Acquaintances\Interaction;
 

--- a/src/Traits/CanBeFavorited.php
+++ b/src/Traits/CanBeFavorited.php
@@ -30,7 +30,7 @@ trait CanBeFavorited
      */
     public function favoriters()
     {
-        return $this->morphToMany(config('auth.providers.users.model'), 'subject',
+        return $this->morphToMany(Interaction::getUserModelName(), 'subject',
             config('acquaintances.tables.interactions'))
                     ->wherePivot('relation', '=', Interaction::RELATION_FAVORITE)
                     ->withPivot(...Interaction::$pivotColumns);

--- a/src/Traits/CanBeFollowed.php
+++ b/src/Traits/CanBeFollowed.php
@@ -30,7 +30,7 @@ trait CanBeFollowed
      */
     public function followers()
     {
-        return $this->morphToMany(config('auth.providers.users.model'), 'subject',
+        return $this->morphToMany(Interaction::getUserModelName(), 'subject',
             config('acquaintances.tables.interactions'))
                     ->wherePivot('relation', '=', Interaction::RELATION_FOLLOW)
                     ->withPivot(...Interaction::$pivotColumns);

--- a/src/Traits/CanBeLiked.php
+++ b/src/Traits/CanBeLiked.php
@@ -29,7 +29,7 @@ trait CanBeLiked
      */
     public function likers()
     {
-        return $this->morphToMany(config('auth.providers.users.model'), 'subject',
+        return $this->morphToMany(Interaction::getUserModelName(), 'subject',
             config('acquaintances.tables.interactions'))
                     ->wherePivot('relation', '=', Interaction::RELATION_LIKE)
                     ->withPivot(...Interaction::$pivotColumns);

--- a/src/Traits/CanBeRated.php
+++ b/src/Traits/CanBeRated.php
@@ -62,7 +62,7 @@ trait CanBeRated
      */
     public function raters($isAllTypes = false)
     {
-        $relation = $this->morphToMany(config('auth.providers.users.model'), 'subject',
+        $relation = $this->morphToMany(Interaction::getUserModelName(), 'subject',
             config('acquaintances.tables.interactions'))
                          ->wherePivot('relation', '=', Interaction::RELATION_RATE);
 

--- a/src/Traits/CanBeSubscribed.php
+++ b/src/Traits/CanBeSubscribed.php
@@ -29,7 +29,7 @@ trait CanBeSubscribed
      */
     public function subscribers()
     {
-        return $this->morphToMany(config('auth.providers.users.model'), 'subject',
+        return $this->morphToMany(Interaction::getUserModelName(), 'subject',
             config('acquaintances.tables.interactions'))
                     ->wherePivot('relation', '=', Interaction::RELATION_SUBSCRIBE)
                     ->withPivot(...Interaction::$pivotColumns);

--- a/src/Traits/CanBeVoted.php
+++ b/src/Traits/CanBeVoted.php
@@ -53,7 +53,7 @@ trait CanBeVoted
      */
     public function voters()
     {
-        return $this->morphToMany(config('auth.providers.users.model'), 'subject',
+        return $this->morphToMany(Interaction::getUserModelName(), 'subject',
             config('acquaintances.tables.interactions'))
                     ->wherePivotIn('relation', [Interaction::RELATION_UPVOTE, Interaction::RELATION_DOWNVOTE])
                     ->withPivot(...Interaction::$pivotColumns);
@@ -66,7 +66,7 @@ trait CanBeVoted
      */
     public function upvoters()
     {
-        return $this->morphToMany(config('auth.providers.users.model'), 'subject',
+        return $this->morphToMany(Interaction::getUserModelName(), 'subject',
             config('acquaintances.tables.interactions'))
                     ->wherePivot('relation', '=', Interaction::RELATION_UPVOTE)
                     ->withPivot(...Interaction::$pivotColumns);
@@ -79,7 +79,7 @@ trait CanBeVoted
      */
     public function downvoters()
     {
-        return $this->morphToMany(config('auth.providers.users.model'), 'subject',
+        return $this->morphToMany(Interaction::getUserModelName(), 'subject',
             config('acquaintances.tables.interactions'))
                     ->wherePivot('relation', '=', Interaction::RELATION_DOWNVOTE)
                     ->withPivot(...Interaction::$pivotColumns);


### PR DESCRIPTION
I noticed that it's not really possible to use a custom User model because the code still references `user_id` though a different model was defined in config. This PR enables the use of custom models.