### PR TITLE
fix: use new user model helper method in CanBeViewed

### DIFF
--- a/src/Traits/CanBeViewed.php
+++ b/src/Traits/CanBeViewed.php
@@ -29,7 +29,7 @@ trait CanBeViewed
      */
     public function viewers()
     {
-        return $this->morphToMany(config('auth.providers.users.model'), 'subject',
+        return $this->morphToMany(Interaction::getUserModelName(), 'subject',
             config('acquaintances.tables.interactions'))
                     ->wherePivot('relation', '=', Interaction::RELATION_VIEW)
                     ->withPivot(...Interaction::$pivotColumns);


### PR DESCRIPTION
Sorry, I was working with the old state before. This will add the new helper method `Interaction::getUserModelName()` in the new view interaction.