### PR TITLE
fix: use id columns

### DIFF
--- a/database/migrations/2018_06_14_000000_create_acquaintances_friendship_table.php
+++ b/database/migrations/2018_06_14_000000_create_acquaintances_friendship_table.php
@@ -10,7 +10,7 @@ class CreateAcquaintancesFriendshipTable extends Migration
     {
 
         Schema::create(config('acquaintances.tables.friendships'), function (Blueprint $table) {
-            $table->increments('id');
+            $table->id();
             $table->morphs('sender');
             $table->morphs('recipient');
             $table->string('status')->default('pending')->comment('pending/accepted/denied/blocked/');

--- a/database/migrations/2018_06_14_000000_create_acquaintances_friendships_groups_table.php
+++ b/database/migrations/2018_06_14_000000_create_acquaintances_friendships_groups_table.php
@@ -13,6 +13,7 @@ class CreateAcquaintancesFriendshipsGroupsTable extends Migration
     {
 
         Schema::create(config('acquaintances.tables.friendship_groups'), function (Blueprint $table) {
+            $table->id();
 
             $table->integer('friendship_id')->unsigned();
             $table->morphs('friend');

--- a/database/migrations/2018_06_14_000000_create_acquaintances_interactions_table.php
+++ b/database/migrations/2018_06_14_000000_create_acquaintances_interactions_table.php
@@ -12,7 +12,8 @@ class CreateAcquaintancesInteractionsTable extends Migration
     public function up()
     {
         Schema::create(config('acquaintances.tables.interactions', 'interactions'), function (Blueprint $table) {
-
+            $table->id();
+            
             $userModel = config('auth.providers.users.model');
             $userModel = (new $userModel);
 


### PR DESCRIPTION
This PR will add ids to the used tables. This can be handy because some Laravel events only trigger when there is a real key field.