### PR TITLE
WIP:  `CanBeActor` trait.

### DIFF
--- a/src/Interaction.php
+++ b/src/Interaction.php
@@ -24,6 +24,7 @@ class Interaction
     public static $pivotColumns = [
         'id',
         'subject_type',
+        'actor_type',
         'relation',
         'relation_value',
         'relation_type',
@@ -121,7 +122,6 @@ class Interaction
     {
         $targets = self::attachPivotsFromRelation($model->{$relation}(), $targets, $class, $updates);
 
-//        dd($relation, $targets);
         return $model->{$relation}($targets->classname)->toggle($targets->targets);
     }
 
@@ -164,7 +164,6 @@ class Interaction
         $result->ids = array_map(function ($target) use ($result) {
             if ($target instanceof Model) {
                 $result->classname = get_class($target);
-
                 return $target->getKey();
             }
 
@@ -216,8 +215,8 @@ class Interaction
 
         return number_format($number / $divisor, $precision).$shorthand;
     }
-    
-    
+
+
 
     public static function getFullModelName($modelClassName)
     {

--- a/src/Interaction.php
+++ b/src/Interaction.php
@@ -46,7 +46,7 @@ class Interaction
         'upvoters' => 'upvote',
         'downvotes' => 'downvote',
         'downvoters' => 'downvote',
-        'ratings' => 'rating',
+        'ratingsTo' => 'rating',
         'raters' => 'rating',
         'views' => 'view',
         'viewers' => 'view',

--- a/src/Models/InteractionRelation.php
+++ b/src/Models/InteractionRelation.php
@@ -31,6 +31,16 @@ class InteractionRelation extends MorphPivot
         return $this->morphTo('subject');
     }
 
+
+    /** Owner of the subject.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function actor()
+    {
+        return $this->morphTo('actor');
+    }
+
     /**
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
@@ -47,9 +57,11 @@ class InteractionRelation extends MorphPivot
      */
     public function scopePopular($query, $type = null)
     {
-        $query->select('subject_id', 'subject_type', \DB::raw('COUNT(*) AS count'))
-              ->groupBy('subject_id', 'subject_type')
-              ->orderByDesc('count');
+        $query->select(
+            'subject_id',
+            'subject_type',
+            \DB::raw('COUNT(*) AS count')
+        )->groupBy('subject_id', 'subject_type')->orderByDesc('count');
 
         if ($type) {
             $query->where('subject_type', $this->normalizeSubjectType($type));
@@ -64,7 +76,10 @@ class InteractionRelation extends MorphPivot
     public function getTable()
     {
         if ( ! $this->table) {
-            $this->table = config('acquaintances.tables.interactions', 'interactions');
+            $this->table = config(
+                'acquaintances.tables.interactions',
+                'interactions'
+            );
         }
 
         return parent::getTable();
@@ -102,7 +117,9 @@ class InteractionRelation extends MorphPivot
         $modelName = $namespace.'\\'.studly_case($type);
 
         if ( ! class_exists($modelName)) {
-            throw new InvalidArgumentException("Model {$modelName} not exists. Please check your config 'acquaintances.model_namespace'.");
+            throw new InvalidArgumentException(
+                "Model {$modelName} not exists. Please check your config 'acquaintances.model_namespace'."
+            );
         }
 
         return $modelName;

--- a/src/Traits/CanBeActor.php
+++ b/src/Traits/CanBeActor.php
@@ -42,14 +42,20 @@ trait CanBeActor
 
     /**
      * @param  array|Model  $models
+     * @param  array|string  $relationTypes
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder
      */
-    public function getRatesVia($models)
+    public function getRatesVia($models, $relationTypes = [])
     {
         return $this->getRelation(Interaction::RELATION_RATE)->whereHasMorph(
             'subject',
             $models
+        )->when(
+            count($relationTypes) > 0,
+            function ($query) use ($relationTypes) {
+                $query->whereIn('relation_type', $relationTypes);
+            }
         );
     }
 

--- a/src/Traits/CanBeActor.php
+++ b/src/Traits/CanBeActor.php
@@ -1,0 +1,150 @@
+<?php
+
+
+namespace Multicaret\Acquaintances\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Multicaret\Acquaintances\Interaction;
+
+trait CanBeActor
+{
+    /**
+     * Check if a model is favorited by given model.
+     *
+     * @param  int|array|\Illuminate\Database\Eloquent\Model  $user
+     *
+     * @return bool
+     */
+    public function isFavoritedBy($user)
+    {
+        return Interaction::isRelationExists($this, 'favoriters', $user);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function getInteractions()
+    {
+        return $this->morphMany(
+            Interaction::getInteractionRelationModelName(),
+            'actor',
+        );
+    }
+
+    public function getRelation($relation)
+    {
+        return $this->getInteractions()->where(
+            'relation',
+            '=',
+            $relation
+        );
+    }
+
+    /**
+     * @param  array|Model  $models
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder
+     */
+    public function getRatesVia($models)
+    {
+        return $this->getRelation(Interaction::RELATION_RATE)->whereHasMorph(
+            'subject',
+            $models
+        );
+    }
+
+
+    /**
+     * @param  array|Model  $models
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder
+     */
+    public function getLikesVia($models
+    ): \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder {
+        return $this->getRelation(Interaction::RELATION_LIKE)->whereHasMorph(
+            'subject',
+            $models
+        );
+    }
+
+    /**
+     * @param  array|Model  $models
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder
+     */
+    public function getFollowsVia($models
+    ): \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder {
+        return $this->getRelation(Interaction::RELATION_FOLLOW)->whereHasMorph(
+            'subject',
+            $models
+        );
+    }
+
+    /**
+     * @param  array|Model  $models
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder
+     */
+    public function getSubscribesVia($models
+    ): \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder {
+        return $this->getRelation(Interaction::RELATION_SUBSCRIBE)
+            ->whereHasMorph(
+                'subject',
+                $models
+            );
+    }
+
+    /**
+     * @param  array|Model  $models
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder
+     */
+    public function getFavoritesVia($models
+    ): \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder {
+        return $this->getRelation(Interaction::RELATION_FAVORITE)
+            ->whereHasMorph(
+                'subject',
+                $models
+            );
+    }
+
+    /**
+     * @param  array|Model  $models
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder
+     */
+    public function getUpVotesVia($models
+    ): \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder {
+        return $this->getRelation(Interaction::RELATION_UPVOTE)->whereHasMorph(
+            'subject',
+            $models
+        );
+    }
+
+    /**
+     * @param  array|Model  $models
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder
+     */
+    public function getDownVotesVia($models
+    ): \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder {
+        return $this->getRelation(Interaction::RELATION_DOWNVOTE)
+            ->whereHasMorph(
+                'subject',
+                $models
+            );
+    }
+
+    /**
+     * @param  array|Model  $models
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder
+     */
+    public function getViewsVia($models
+    ): \Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Builder {
+        return $this->getRelation(Interaction::RELATION_VIEW)->whereHasMorph(
+            'subject',
+            $models
+        );
+    }
+}

--- a/src/Traits/CanFavorite.php
+++ b/src/Traits/CanFavorite.php
@@ -19,11 +19,28 @@ trait CanFavorite
      *
      * @return array
      */
-    public function favorite($targets, $class = __CLASS__)
+    public function favorite($targets, $class = __CLASS__, $actor = null)
     {
         Event::dispatch('acq.favorites.favorite', [$this, $targets]);
 
-        return Interaction::attachRelations($this, 'favorites', $targets, $class);
+        $updates = [];
+        if ($actor) {
+            $updates = array_merge(
+                $updates,
+                [
+                    'actor_type' => $actor->getMorphClass(),
+                    'actor_id'   => $actor->id,
+                ]
+            );
+        }
+
+        return Interaction::attachRelations(
+            $this,
+            'favorites',
+            $targets,
+            $class,
+            $updates
+        );
     }
 
     /**
@@ -38,7 +55,12 @@ trait CanFavorite
     {
         Event::dispatch('acq.favorites.unfavorite', [$this, $targets]);
 
-        return Interaction::detachRelations($this, 'favorites', $targets, $class);
+        return Interaction::detachRelations(
+            $this,
+            'favorites',
+            $targets,
+            $class
+        );
     }
 
     /**
@@ -51,7 +73,12 @@ trait CanFavorite
      */
     public function toggleFavorite($targets, $class = __CLASS__)
     {
-        return Interaction::toggleRelations($this, 'favorites', $targets, $class);
+        return Interaction::toggleRelations(
+            $this,
+            'favorites',
+            $targets,
+            $class
+        );
     }
 
     /**
@@ -64,7 +91,12 @@ trait CanFavorite
      */
     public function hasFavorited($target, $class = __CLASS__)
     {
-        return Interaction::isRelationExists($this, 'favorites', $target, $class);
+        return Interaction::isRelationExists(
+            $this,
+            'favorites',
+            $target,
+            $class
+        );
     }
 
     /**
@@ -76,10 +108,13 @@ trait CanFavorite
      */
     public function favorites($class = __CLASS__)
     {
-        return $this->morphedByMany($class, 'subject',
-            config('acquaintances.tables.interactions'))
-                    ->wherePivot('relation', '=', Interaction::RELATION_FAVORITE)
-                    ->withPivot(...Interaction::$pivotColumns)
-                    ->using(Interaction::getInteractionRelationModelName());
+        return $this->morphedByMany(
+            $class,
+            'subject',
+            config('acquaintances.tables.interactions')
+        )->wherePivot('relation', '=', Interaction::RELATION_FAVORITE)
+            ->withPivot(...Interaction::$pivotColumns)->using(
+                Interaction::getInteractionRelationModelName()
+            );
     }
 }

--- a/src/Traits/CanFollow.php
+++ b/src/Traits/CanFollow.php
@@ -21,11 +21,27 @@ trait CanFollow
      *
      * @throws \Exception
      */
-    public function follow($targets, $class = __CLASS__)
+    public function follow($targets, $class = __CLASS__, $actor = null)
     {
         Event::dispatch('acq.followships.follow', [$this, $targets]);
+        $updates = [];
+        if ($actor) {
+            $updates = array_merge(
+                $updates,
+                [
+                    'actor_type' => $actor->getMorphClass(),
+                    'actor_id'   => $actor->id,
+                ]
+            );
+        }
 
-        return Interaction::attachRelations($this, 'followings', $targets, $class);
+        return Interaction::attachRelations(
+            $this,
+            'followings',
+            $targets,
+            $class,
+            $updates
+        );
     }
 
     /**
@@ -40,7 +56,12 @@ trait CanFollow
     {
         Event::dispatch('acq.followships.unfollow', [$this, $targets]);
 
-        return Interaction::detachRelations($this, 'followings', $targets, $class);
+        return Interaction::detachRelations(
+            $this,
+            'followings',
+            $targets,
+            $class
+        );
     }
 
     /**
@@ -55,7 +76,12 @@ trait CanFollow
      */
     public function toggleFollow($targets, $class = __CLASS__)
     {
-        return Interaction::toggleRelations($this, 'followings', $targets, $class);
+        return Interaction::toggleRelations(
+            $this,
+            'followings',
+            $targets,
+            $class
+        );
     }
 
     /**
@@ -68,7 +94,12 @@ trait CanFollow
      */
     public function isFollowing($target, $class = __CLASS__)
     {
-        return Interaction::isRelationExists($this, 'followings', $target, $class);
+        return Interaction::isRelationExists(
+            $this,
+            'followings',
+            $target,
+            $class
+        );
     }
 
     /**
@@ -80,10 +111,12 @@ trait CanFollow
      */
     public function followings($class = __CLASS__)
     {
-        return $this->morphedByMany($class, 'subject',
-            config('acquaintances.tables.interactions'))
-                    ->wherePivot('relation', '=', Interaction::RELATION_FOLLOW)
-                    ->withPivot(...Interaction::$pivotColumns)
-                    ->using(Interaction::getInteractionRelationModelName());
+        return $this->morphedByMany(
+            $class,
+            'subject',
+            config('acquaintances.tables.interactions')
+        )->wherePivot('relation', '=', Interaction::RELATION_FOLLOW)->withPivot(
+            ...Interaction::$pivotColumns
+        )->using(Interaction::getInteractionRelationModelName());
     }
 }

--- a/src/Traits/CanRate.php
+++ b/src/Traits/CanRate.php
@@ -58,7 +58,7 @@ trait CanRate
     {
         Event::dispatch('acq.ratings.rate', [$this, $targets]);
 
-        return Interaction::attachRelations($this, 'ratings', $targets, $class, [
+        return Interaction::attachRelations($this, 'ratingsTo', $targets, $class, [
             'relation_value' => $amount,
             'relation_type' => $this->rateType($ratingType),
         ]);
@@ -78,7 +78,7 @@ trait CanRate
     {
         Event::dispatch('acq.ratings.unrate', [$this, $targets]);
 
-        return Interaction::detachRelations($this, 'ratings', $targets, $class, [
+        return Interaction::detachRelations($this, 'ratingsTo', $targets, $class, [
             'relation_type' => $this->rateType($ratingType),
         ]);
     }
@@ -97,7 +97,7 @@ trait CanRate
      */
     public function toggleRate($targets, float $amount, $ratingType = null, $class = __CLASS__)
     {
-        return Interaction::toggleRelations($this, 'ratings', $targets, $class, [
+        return Interaction::toggleRelations($this, 'ratingsTo', $targets, $class, [
             'relation_value' => $amount,
             'relation_type' => $this->rateType($ratingType),
         ]);
@@ -114,7 +114,7 @@ trait CanRate
      */
     public function hasRated($target, $ratingType = null, $class = __CLASS__)
     {
-        return Interaction::isRelationExists($this, 'ratings', $target, $class, [
+        return Interaction::isRelationExists($this, 'ratingsTo', $target, $class, [
             'relation_type' => $this->rateType($ratingType),
         ]);
     }

--- a/src/Traits/CanSubscribe.php
+++ b/src/Traits/CanSubscribe.php
@@ -21,11 +21,28 @@ trait CanSubscribe
      *
      * @throws \Exception
      */
-    public function subscribe($targets, $class = __CLASS__)
+    public function subscribe($targets, $class = __CLASS__, $actor = null)
     {
         Event::dispatch('acq.subscriptions.subscribe', [$this, $targets]);
 
-        return Interaction::attachRelations($this, 'subscriptions', $targets, $class);
+        $updates = [];
+        if ($actor) {
+            $updates = array_merge(
+                $updates,
+                [
+                    'actor_type' => $actor->getMorphClass(),
+                    'actor_id'   => $actor->id,
+                ]
+            );
+        }
+
+        return Interaction::attachRelations(
+            $this,
+            'subscriptions',
+            $targets,
+            $class,
+            $updates
+        );
     }
 
     /**
@@ -40,7 +57,12 @@ trait CanSubscribe
     {
         Event::dispatch('acq.subscriptions.unsubscribe', [$this, $targets]);
 
-        return Interaction::detachRelations($this, 'subscriptions', $targets, $class);
+        return Interaction::detachRelations(
+            $this,
+            'subscriptions',
+            $targets,
+            $class
+        );
     }
 
     /**
@@ -55,7 +77,12 @@ trait CanSubscribe
      */
     public function toggleSubscribe($targets, $class = __CLASS__)
     {
-        return Interaction::toggleRelations($this, 'subscriptions', $targets, $class);
+        return Interaction::toggleRelations(
+            $this,
+            'subscriptions',
+            $targets,
+            $class
+        );
     }
 
     /**
@@ -68,7 +95,12 @@ trait CanSubscribe
      */
     public function hasSubscribed($target, $class = __CLASS__)
     {
-        return Interaction::isRelationExists($this, 'subscriptions', $target, $class);
+        return Interaction::isRelationExists(
+            $this,
+            'subscriptions',
+            $target,
+            $class
+        );
     }
 
     /**
@@ -80,10 +112,13 @@ trait CanSubscribe
      */
     public function subscriptions($class = __CLASS__)
     {
-        return $this->morphedByMany($class, 'subject',
-            config('acquaintances.tables.interactions'))
-                    ->wherePivot('relation', '=', Interaction::RELATION_SUBSCRIBE)
-                    ->withPivot(...Interaction::$pivotColumns)
-                    ->using(Interaction::getInteractionRelationModelName());
+        return $this->morphedByMany(
+            $class,
+            'subject',
+            config('acquaintances.tables.interactions')
+        )->wherePivot('relation', '=', Interaction::RELATION_SUBSCRIBE)
+            ->withPivot(...Interaction::$pivotColumns)->using(
+                Interaction::getInteractionRelationModelName()
+            );
     }
 }

--- a/src/Traits/CanView.php
+++ b/src/Traits/CanView.php
@@ -21,9 +21,20 @@ trait CanView
      *
      * @throws \Exception
      */
-    public function view($targets, $class = __CLASS__)
+    public function view($targets, $class = __CLASS__, $actor = null)
     {
         Event::dispatch('acq.views.view', [$this, $targets]);
+
+        $updates = [];
+        if ($actor) {
+            $updates = array_merge(
+                $updates,
+                [
+                    'actor_type' => $actor->getMorphClass(),
+                    'actor_id'   => $actor->id,
+                ]
+            );
+        }
 
         return Interaction::attachRelations($this, 'views', $targets, $class);
     }
@@ -80,10 +91,12 @@ trait CanView
      */
     public function views($class = __CLASS__)
     {
-        return $this->morphedByMany($class, 'subject',
-            config('acquaintances.tables.interactions'))
-                    ->wherePivot('relation', '=', Interaction::RELATION_VIEW)
-                    ->withPivot(...Interaction::$pivotColumns)
-                    ->using(Interaction::getInteractionRelationModelName());
+        return $this->morphedByMany(
+            $class,
+            'subject',
+            config('acquaintances.tables.interactions')
+        )->wherePivot('relation', '=', Interaction::RELATION_VIEW)->withPivot(
+            ...Interaction::$pivotColumns
+        )->using(Interaction::getInteractionRelationModelName());
     }
 }

--- a/src/Traits/CanVote.php
+++ b/src/Traits/CanVote.php
@@ -23,11 +23,32 @@ trait CanVote
      *
      * @throws \Exception
      */
-    public function vote($targets, $type = 'upvote', $class = __CLASS__)
-    {
+    public function vote(
+        $targets,
+        $type = 'upvote',
+        $class = __CLASS__,
+        $actor = null
+    ) {
         $this->cancelVote($targets);
 
-        return Interaction::attachRelations($this, Str::plural($type), $targets, $class);
+        $updates = [];
+        if ($actor) {
+            $updates = array_merge(
+                $updates,
+                [
+                    'actor_type' => $actor->getMorphClass(),
+                    'actor_id'   => $actor->id,
+                ]
+            );
+        }
+
+        return Interaction::attachRelations(
+            $this,
+            Str::plural($type),
+            $targets,
+            $class,
+            $updates
+        );
     }
 
     /**
@@ -104,7 +125,12 @@ trait CanVote
      */
     public function hasDownvoted($target, $class = __CLASS__)
     {
-        return Interaction::isRelationExists($this, 'downvotes', $target, $class);
+        return Interaction::isRelationExists(
+            $this,
+            'downvotes',
+            $target,
+            $class
+        );
     }
 
     /**
@@ -116,11 +142,16 @@ trait CanVote
      */
     public function votes($class = __CLASS__)
     {
-        return $this->morphedByMany($class, 'subject',
-            config('acquaintances.tables.interactions'))
-                    ->wherePivotIn('relation', [Interaction::RELATION_UPVOTE, Interaction::RELATION_DOWNVOTE])
-                    ->withPivot(...Interaction::$pivotColumns)
-                    ->using(Interaction::getInteractionRelationModelName());
+        return $this->morphedByMany(
+            $class,
+            'subject',
+            config('acquaintances.tables.interactions')
+        )->wherePivotIn(
+            'relation',
+            [Interaction::RELATION_UPVOTE, Interaction::RELATION_DOWNVOTE]
+        )->withPivot(...Interaction::$pivotColumns)->using(
+            Interaction::getInteractionRelationModelName()
+        );
     }
 
     /**
@@ -132,11 +163,13 @@ trait CanVote
      */
     public function upvotes($class = __CLASS__)
     {
-        return $this->morphedByMany($class, 'subject',
-            config('acquaintances.tables.interactions'))
-                    ->wherePivot('relation', '=', Interaction::RELATION_UPVOTE)
-                    ->withPivot(...Interaction::$pivotColumns)
-                    ->using(Interaction::getInteractionRelationModelName());
+        return $this->morphedByMany(
+            $class,
+            'subject',
+            config('acquaintances.tables.interactions')
+        )->wherePivot('relation', '=', Interaction::RELATION_UPVOTE)->withPivot(
+            ...Interaction::$pivotColumns
+        )->using(Interaction::getInteractionRelationModelName());
     }
 
     /**
@@ -148,10 +181,13 @@ trait CanVote
      */
     public function downvotes($class = __CLASS__)
     {
-        return $this->morphedByMany($class, 'subject',
-            config('acquaintances.tables.interactions'))
-                    ->wherePivot('relation', '=', Interaction::RELATION_DOWNVOTE)
-                    ->withPivot(...Interaction::$pivotColumns)
-                    ->using(Interaction::getInteractionRelationModelName());
+        return $this->morphedByMany(
+            $class,
+            'subject',
+            config('acquaintances.tables.interactions')
+        )->wherePivot('relation', '=', Interaction::RELATION_DOWNVOTE)
+            ->withPivot(...Interaction::$pivotColumns)->using(
+                Interaction::getInteractionRelationModelName()
+            );
     }
 }


### PR DESCRIPTION
Hey!

While implementing rating in my platform I notice there's some missing feature. 
First of all, let me explain why we need another `trait`:
existing traits allow us to make easily 2 point interactions where users interact with something. this is all good use case but when you would like to implement something like the collective score for the provider.

Case example.

there's consumer, job, and the provider
you would like to give rate to provider but if you directly rate the provider without mid entity you can only do that once. 
which is game blocker; 

A better way to implement this would be user rates job and someone gets credits from it. 
so introduce `nullableMorph('actor')` in interactions table.
where you can define who the actor getting credits from.

through this, 

the provider could have an average rating base on the jobs he has done. 
the consumer could have an average rating base on the jobs created.

I don't think this branch is mature enough to merge in yet but would love to take opinions. 

Cheers 🍻 

example method on Models\User.php
```
    public function getJobSuccessRate()
    {
        $totalJobSuccessRate = $this->getRatesVia(
            [Job::class]
        )->average(
            'relation_value'
        );
        return Interaction::numberToReadable(
            $totalJobSuccessRate
        );
    }

```

an example method to rate 
```
        $jobSession->job->author->rate(
            $jobSession,
            5,
            JobSession::RATING_GENERAL,
            null,
            $jobSession->developer
        );

```

