### PR TITLE
Remove Dollar Sign from Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ easily design your social-like System (Facebook, Twitter, Foursquare...etc).
 First, install the package through Composer.
 
 ```sh
-$ composer require multicaret/laravel-acquaintances
+composer require multicaret/laravel-acquaintances
 ```
 
 Laravel 5.8 and up => version 2.x (branch master)
@@ -99,7 +99,7 @@ Laravel 5.7 and below => version 1.x (branch v1)
 Publish config and migrations:
 
 ```sh
-$ php artisan vendor:publish --provider="Multicaret\Acquaintances\AcquaintancesServiceProvider"
+php artisan vendor:publish --provider="Multicaret\Acquaintances\AcquaintancesServiceProvider"
 ```
 
 Configure the published config in:
@@ -111,7 +111,7 @@ config/acquaintances.php
 Finally, migrate the database to create the table:
 
 ```sh
-$ php artisan migrate
+php artisan migrate
 ```
 
 ---


### PR DESCRIPTION
This makes them easier to copy from GitHub when using the "copy" button. Before you would get the dollar sign as well, which is annoying if you paste it into your terminal.
![image](https://user-images.githubusercontent.com/3212673/140598142-befba724-eadd-406b-bc7e-918543434900.png)
