### PR TITLE
Solve isRelationExists causing potential ambiguous errors by not spec…

### DIFF
--- a/src/Interaction.php
+++ b/src/Interaction.php
@@ -67,7 +67,7 @@ class Interaction
         $target = self::formatTargets($target, $class ?: config('auth.providers.users.model'), $updates);
 
         return $model->{$relation}($target->classname)
-                     ->where($class ? 'subject_id' : 'user_id', head($target->ids))
+                     ->where($class ? config('acquaintances.tables.interactions', 'interactions') . '.subject_id' : config('acquaintances.tables.interactions', 'interactions') . '.user_id', head($target->ids))
                      ->exists();
     }
 
@@ -216,8 +216,8 @@ class Interaction
 
         return number_format($number / $divisor, $precision).$shorthand;
     }
-    
-    
+
+
 
     public static function getFullModelName($modelClassName)
     {


### PR DESCRIPTION
On a project I'm working on that I use this package for, I have some complicated global scope needs. Some of those scopes involve joins, and the best way I found to prevent those causing ambiguous field errors was by making sure all where statements are fully qualified by overriding Laravel's builder class.

However this packages was giving me SQL errors about subject_id and user_id being ambiguous in some instances, like when using hasLiked and hasSubscribed on the user model.

Regardless of the motivation, I think packages should fully qualify their field names in queries to prevent possible errors. Considering the table name for interactions is already part of the config, this was an easy fix and instead of overriding the classes myself I thought I'd put out a PR.

This is my first time ever committing a proposed fix to a public repository, please let me know if I did anything wrong. Thanks for the amazing package.