### PR TITLE
Added three new methods to the canFollow trait to expose counts. 

### DIFF
--- a/src/Traits/CanFollow.php
+++ b/src/Traits/CanFollow.php
@@ -80,11 +80,46 @@ trait CanFollow
      */
     public function followings($class = __CLASS__)
     {
-        return $this->morphedByMany($class, 'subject',
-            config('acquaintances.tables.interactions'))
-                    ->wherePivot('relation', '=', Interaction::RELATION_FOLLOW)
-                    ->withPivot(...Interaction::$pivotColumns)
-                    ->using(Interaction::getInteractionRelationModelName())
-                    ->withTimestamps();
+        return $this->morphedByMany(
+            $class,
+            'subject',
+            config('acquaintances.tables.interactions')
+        )
+            ->wherePivot('relation', '=', Interaction::RELATION_FOLLOW)
+            ->withPivot(...Interaction::$pivotColumns)
+            ->using(Interaction::getInteractionRelationModelName())
+            ->withTimestamps();
+    }
+
+    /**
+     * Return following count.
+     *
+     * @return int
+     */
+    public function followingCount()
+    {
+        return $this->followings()->get()->count();
+    }
+
+    /**
+     * Get followingCount attribute
+     *
+     * @return int
+     */
+    public function getFollowingCountAttribute()
+    {
+        return $this->followingCount();
+    }
+
+    /**
+     * Return followingCount in a readable format.
+     *
+     * @param integer $precision
+     * @param string $divisors
+     * @return int|float|string
+     */
+    public function followingCountReadable(int $precision = 1, string $divisors = null)
+    {
+        return Interaction::numberToReadable($this->followingCount(), $precision, $divisors);
     }
 }


### PR DESCRIPTION
This PR will enable people to expose counts of models a user is following.

followingCount()
getFollowingCountAttribute()
followingCountReadable()

DOCUMENTATION
```
\Multicaret\Acquaintances\Traits\CanFollow

$user->follow($targets);
$user->unfollow($targets);
$user->toggleFollow($targets);
$user->followings()->get(); // App\User:class
$user->followings(App\Post::class)->get();
$user->isFollowing($target);
$object->followingCount(); // or as attribute $object->following_count
$object->followingCountReadable(); // return readable number with precision, i.e: 5.2K
```