### PR TITLE
Add CanReport & CanBeReported Classes to the traits

### DIFF
--- a/src/Interaction.php
+++ b/src/Interaction.php
@@ -20,6 +20,7 @@ class Interaction
     const RELATION_DOWNVOTE = 'downvote';
     const RELATION_RATE = 'rating';
     const RELATION_VIEW = 'view';
+    const RELATION_REPORT = 'report';
 
     public static $pivotColumns = [
         'id',
@@ -50,6 +51,8 @@ class Interaction
         'raters' => 'rating',
         'views' => 'view',
         'viewers' => 'view',
+        'reporters' => 'report',
+        'reports' => 'report',
     ];
 
     /**
@@ -122,7 +125,7 @@ class Interaction
     {
         $targets = self::attachPivotsFromRelation($model->{$relation}(), $targets, $class, $updates);
 
-//        dd($relation, $targets);
+        //        dd($relation, $targets);
         return $model->{$relation}($targets->classname)->toggle($targets->targets);
     }
 
@@ -140,7 +143,7 @@ class Interaction
     {
         $essentialUpdates = array_merge($updates, [
             'relation' => self::getRelationTypeFromRelation($morph),
-//            'created_at' => Carbon::now(),
+            //            'created_at' => Carbon::now(),
         ]);
 
         return self::formatTargets($targets, $class, $essentialUpdates);
@@ -158,7 +161,7 @@ class Interaction
         $result = new stdClass();
         $result->classname = $classname;
 
-        if ( ! is_array($targets)) {
+        if (! is_array($targets)) {
             $targets = [$targets];
         }
 
@@ -172,8 +175,10 @@ class Interaction
             return intval($target);
         }, $targets);
 
-        $result->targets = empty($update) ? $result->ids : array_combine($result->ids,
-            array_pad([], count($result->ids), $update));
+        $result->targets = empty($update) ? $result->ids : array_combine(
+            $result->ids,
+            array_pad([], count($result->ids), $update)
+        );
 
         return $result;
     }
@@ -187,7 +192,7 @@ class Interaction
      */
     protected static function getRelationTypeFromRelation(MorphToMany $relation)
     {
-        if ( ! \array_key_exists($relation->getRelationName(), self::$relationMap)) {
+        if (! \array_key_exists($relation->getRelationName(), self::$relationMap)) {
             throw new \Exception('Invalid relation definition.');
         }
 
@@ -198,7 +203,7 @@ class Interaction
     {
         $shorthand = '';
         $divisor = pow(1000, 0);
-        if ( ! isset($divisors)) {
+        if (! isset($divisors)) {
             $divisors = [
                 $divisor => $shorthand, // 1000^0 == 1
                 pow(1000, 1) => 'K', // Thousand
@@ -215,7 +220,7 @@ class Interaction
             }
         }
 
-        return number_format($number / $divisor, $precision).$shorthand;
+        return number_format($number / $divisor, $precision) . $shorthand;
     }
 
 

--- a/src/Traits/CanBeReported.php
+++ b/src/Traits/CanBeReported.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace Multicaret\Acquaintances\Traits;
+
+use Multicaret\Acquaintances\Interaction;
+
+
+/**
+ * Trait CanBeReported.
+ */
+trait CanBeReported
+{
+    /**
+     * Check if a model is reported by given model.
+     *
+     * @param  int|array|\Illuminate\Database\Eloquent\Model  $user
+     *
+     * @return bool
+     */
+    public function isReportedBy($user)
+    {
+        return Interaction::isRelationExists($this, 'reporters', $user);
+    }
+
+    /**
+     * Return reporters.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function reporters()
+    {
+        return $this->morphToMany(
+            Interaction::getUserModelName(),
+            'subject',
+            config('acquaintances.tables.interactions')
+        )
+            ->wherePivot('relation', '=', Interaction::RELATION_FAVORITE)
+            ->withPivot(...Interaction::$pivotColumns)
+            ->using(Interaction::getInteractionRelationModelName())
+            ->withTimestamps();
+    }
+
+    public function reportersCount()
+    {
+        return $this->reporters()->count();
+    }
+
+    public function getreportersCountAttribute()
+    {
+        return $this->reportersCount();
+    }
+
+    public function reportersCountReadable($precision = 1, $divisors = null)
+    {
+        return Interaction::numberToReadable($this->reportersCount(), $precision, $divisors);
+    }
+}

--- a/src/Traits/CanReport.php
+++ b/src/Traits/CanReport.php
@@ -55,14 +55,14 @@ trait CanReport
     }
 
     /**
-     * Check if a model is reportd given model.
+     * Check if a model is reported given model.
      *
      * @param  int|array|\Illuminate\Database\Eloquent\Model  $target
      * @param  string  $class
      *
      * @return bool
      */
-    public function hasReportd($target, $class = __CLASS__)
+    public function hasReported($target, $class = __CLASS__)
     {
         return Interaction::isRelationExists($this, 'reports', $target, $class);
     }

--- a/src/Traits/CanReport.php
+++ b/src/Traits/CanReport.php
@@ -1,0 +1,89 @@
+<?php
+
+
+namespace Multicaret\Acquaintances\Traits;
+
+use Illuminate\Support\Facades\Event;
+use Multicaret\Acquaintances\Interaction;
+
+/**
+ * Trait CanReport.
+ */
+trait CanReport
+{
+    /**
+     * Report an item or items.
+     *
+     * @param  int|array|\Illuminate\Database\Eloquent\Model  $targets
+     * @param  string  $class
+     *
+     * @return array
+     */
+    public function report($targets, $class = __CLASS__)
+    {
+        Event::dispatch('acq.reports.report', [$this, $targets]);
+
+        return Interaction::attachRelations($this, 'reports', $targets, $class);
+    }
+
+    /**
+     * Unreport an item or items.
+     *
+     * @param  int|array|\Illuminate\Database\Eloquent\Model  $targets
+     * @param  string  $class
+     *
+     * @return array
+     */
+    public function unreport($targets, $class = __CLASS__)
+    {
+        Event::dispatch('acq.reports.unreport', [$this, $targets]);
+
+        return Interaction::detachRelations($this, 'reports', $targets, $class);
+    }
+
+    /**
+     * Toggle report an item or items.
+     *
+     * @param  int|array|\Illuminate\Database\Eloquent\Model  $targets
+     * @param  string  $class
+     *
+     * @return array
+     */
+    public function toggleReport($targets, $class = __CLASS__)
+    {
+        return Interaction::toggleRelations($this, 'reports', $targets, $class);
+    }
+
+    /**
+     * Check if a model is reportd given model.
+     *
+     * @param  int|array|\Illuminate\Database\Eloquent\Model  $target
+     * @param  string  $class
+     *
+     * @return bool
+     */
+    public function hasReportd($target, $class = __CLASS__)
+    {
+        return Interaction::isRelationExists($this, 'reports', $target, $class);
+    }
+
+    /**
+     * Return item reports.
+     *
+     * @param  string  $class
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function reports($class = __CLASS__)
+    {
+        return $this->morphedByMany(
+            $class,
+            'subject',
+            config('acquaintances.tables.interactions')
+        )
+            ->wherePivot('relation', '=', Interaction::RELATION_REPORT)
+            ->withPivot(...Interaction::$pivotColumns)
+            ->using(Interaction::getInteractionRelationModelName())
+            ->withTimestamps();
+    }
+}


### PR DESCRIPTION
CanReport and CanBeReported enables users to report a model to flag a model as inapropriate to the platform's administrators / moderators. It works exactly like 'favorite' but is used like block but without any direct consequenses to the friendship relationship. In practice a moderator would then be able to suspend/ban/delete a User/Post/Other Model that has been reported.

DOCUMENTATION
```
Report
\Multicaret\Acquaintances\Traits\CanReport

$user->report($targets);
$user->unreport($targets);
$user->toggleReport($targets);
$user->hasReported($target);
$user->reports()->get(); // App\User:class
$user->reports(App\Post::class)->get();

\Multicaret\Acquaintances\Traits\CanBeReported

$object->reporters()->get(); // or $object->reporters
$object->isReportedBy($user);
$object->reportersCount(); // or as attribute $object->reporters_count
$object->reportersCountReadable(); // return readable number with precision, i.e: 5.2K
```
