### PR TITLE
Fix PHP 8.4 compatibility: Add explicit nullable type declaration for followingCountReadable

### DIFF
--- a/src/Traits/CanFollow.php
+++ b/src/Traits/CanFollow.php
@@ -115,10 +115,10 @@ trait CanFollow
      * Return followingCount in a readable format.
      *
      * @param  integer  $precision
-     * @param  string  $divisors
+     * @param  string|null  $divisors
      * @return int|float|string
      */
-    public function followingCountReadable(int $precision = 1, string $divisors = null)
+    public function followingCountReadable(int $precision = 1, ?string $divisors = null)
     {
         return Interaction::numberToReadable($this->followingCount(), $precision, $divisors);
     }


### PR DESCRIPTION
PHP 8.4 has introduced a stricter type declarations and is issuing warnings for implicit nullable parameters (parameters with default value `null` but without explicit nullable type declaration).

Which is causing such warning in the logs:
`[2025-08-04 20:24:37] laravel.WARNING: Multicaret\Acquaintances\Traits\CanFollow::followingCountReadable(): Implicitly marking parameter $divisors as nullable is deprecated, the explicit nullable type must be used instead in /srv/project/vendor/multicaret/laravel-acquaintances/src/Traits/CanFollow.php on line 121  
`

This commit fixed such issue by change the implicit nullable type declaration to a nullable type declaration for followingCountReadable in CanFollow.php, which seems to be the only place has been affected by that issue in this project.